### PR TITLE
Formulas search box

### DIFF
--- a/web/html/src/components/FormulaForm.tsx
+++ b/web/html/src/components/FormulaForm.tsx
@@ -340,7 +340,7 @@ class FormulaForm extends React.Component<Props, State> {
                   <SearchField
                       placeholder={t("Search by formula's group name")}
                       criteria={this.state.searchCriteria}
-                      onSearch={(v) => this.setState({ searchCriteria: v }) } />
+                      onSearch={(v) => this.setState({ searchCriteria: v, sectionsExpanded: "expanded"}) } />
                   <hr />
                   <p>{text(this.state.formulaMetadata.description)}</p>
                   <hr />

--- a/web/html/src/components/FormulaForm.tsx
+++ b/web/html/src/components/FormulaForm.tsx
@@ -13,6 +13,7 @@ import {
 import { SectionToolbar } from "components/section-toolbar/section-toolbar";
 import { DEPRECATED_unsafeEquals } from "utils/legacy";
 import { BootstrapPanel } from "components/panels/BootstrapPanel";
+import { SearchField } from "./table/SearchField";
 
 const capitalize = Utils.capitalize;
 
@@ -61,6 +62,7 @@ type State = {
   warnings: string[];
   errors: string[];
   sectionsExpanded: string;
+  searchCriteria: string;
 };
 
 class FormulaForm extends React.Component<Props, State> {
@@ -78,6 +80,7 @@ class FormulaForm extends React.Component<Props, State> {
       warnings: [],
       errors: [],
       sectionsExpanded: "collapsed",
+      searchCriteria: "",
     };
 
     window.addEventListener(
@@ -273,6 +276,7 @@ class FormulaForm extends React.Component<Props, State> {
           scope={this.props.scope}
           sectionsExpanded={this.state.sectionsExpanded}
           setSectionsExpanded={(status) => this.setState({ sectionsExpanded: status })}
+          searchCriteria={this.state.searchCriteria}
         >
           <div>
             {defaultMessage}
@@ -333,6 +337,11 @@ class FormulaForm extends React.Component<Props, State> {
                 }
               >
                 <div className="formula-content">
+                  <SearchField
+                      placeholder={t("Search by formula's group name")}
+                      criteria={this.state.searchCriteria}
+                      onSearch={(v) => this.setState({ searchCriteria: v }) } />
+                  <hr />
                   <p>{text(this.state.formulaMetadata.description)}</p>
                   <hr />
                   <FormulaFormRenderer />

--- a/web/html/src/components/formulas/EditGroup.tsx
+++ b/web/html/src/components/formulas/EditGroup.tsx
@@ -4,10 +4,12 @@ import {
   ElementDefinition,
   generateFormulaComponent,
   generateFormulaComponentForId,
+  isFiltered,
 } from "./FormulaComponentGenerator";
 import HelpIcon from "components/utils/HelpIcon";
 import "./formula-form.css";
 import SectionToggle from "./SectionToggle";
+import { Highlight } from "components/table/Highlight";
 
 const EditGroupSubtype = Formulas.EditGroupSubtype;
 const getEditGroupSubtype = Formulas.getEditGroupSubtype;
@@ -26,6 +28,7 @@ type EditGroupProps = {
   sectionsExpanded: string;
   setSectionsExpanded: (string) => void;
   isVisibleByCriteria?: any;
+  criteria: string;
 };
 
 type EditGroupState = {
@@ -117,7 +120,9 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
         >
           <div className="group-heading">
             <SectionToggle setVisible={this.setVisible} isVisible={this.isVisible}>
-              <h4>{this.props.element.$name}</h4>
+              <h4>
+                <Highlight enabled={isFiltered(this.props.criteria)} text={this.props.element.$name} highlight={this.props.criteria} />
+              </h4>
             </SectionToggle>
             <i
               className="fa fa-plus"

--- a/web/html/src/components/formulas/EditGroup.tsx
+++ b/web/html/src/components/formulas/EditGroup.tsx
@@ -25,6 +25,7 @@ type EditGroupProps = {
   element: ElementDefinition;
   sectionsExpanded: string;
   setSectionsExpanded: (string) => void;
+  isVisibleByCriteria?: any;
 };
 
 type EditGroupState = {
@@ -109,44 +110,46 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
     }
 
     return (
-      <div
-        id={this.props.id}
-        className={this.isVisible() ? "formula-content-section-open" : "formula-content-section-closed"}
-      >
-        <div className="group-heading">
-          <SectionToggle setVisible={this.setVisible} isVisible={this.isVisible}>
-            <h4>{this.props.element.$name}</h4>
-          </SectionToggle>
-          <i
-            className="fa fa-plus"
-            id={this.props.id + "#add_item"}
-            title={
-              this.props.element.$maxItems! <= this.props.value.length ? "Max number of items reached" : "Add Item"
-            }
-            onClick={this.handleAddItem}
-            /* @ts-expect-error: The property `disabled` doesn't exist on the `<i>` tag, but this was here historically */
-            disabled={this.props.element.$maxItems! <= this.props.value.length || this.props.disabled}
-          ></i>
+      this.props.isVisibleByCriteria?.() ?
+        <div
+          id={this.props.id}
+          className={this.isVisible() ? "formula-content-section-open" : "formula-content-section-closed"}
+        >
+          <div className="group-heading">
+            <SectionToggle setVisible={this.setVisible} isVisible={this.isVisible}>
+              <h4>{this.props.element.$name}</h4>
+            </SectionToggle>
+            <i
+              className="fa fa-plus"
+              id={this.props.id + "#add_item"}
+              title={
+                this.props.element.$maxItems! <= this.props.value.length ? "Max number of items reached" : "Add Item"
+              }
+              onClick={this.handleAddItem}
+              /* @ts-expect-error: The property `disabled` doesn't exist on the `<i>` tag, but this was here historically */
+              disabled={this.props.element.$maxItems! <= this.props.value.length || this.props.disabled}
+            ></i>
+          </div>
+          <div>
+            {this.state.visible ? (
+              <React.Fragment>
+                {"$help" in this.props.element ? <p>{this.props.element.$help}</p> : null}
+                <Component
+                  handleRemoveItem={this.handleRemoveItem}
+                  isDisabled={this.isDisabled()}
+                  id={this.props.id}
+                  key={this.props.key}
+                  element={this.props.element}
+                  value={this.props.value}
+                  sectionsExpanded={this.props.sectionsExpanded}
+                  setSectionsExpanded={this.props.setSectionsExpanded}
+                  formulaForm={this.props.formulaForm}
+                />
+              </React.Fragment>
+            ) : null}
+          </div>
         </div>
-        <div>
-          {this.state.visible ? (
-            <React.Fragment>
-              {"$help" in this.props.element ? <p>{this.props.element.$help}</p> : null}
-              <Component
-                handleRemoveItem={this.handleRemoveItem}
-                isDisabled={this.isDisabled()}
-                id={this.props.id}
-                key={this.props.key}
-                element={this.props.element}
-                value={this.props.value}
-                sectionsExpanded={this.props.sectionsExpanded}
-                setSectionsExpanded={this.props.setSectionsExpanded}
-                formulaForm={this.props.formulaForm}
-              />
-            </React.Fragment>
-          ) : null}
-        </div>
-      </div>
+        : null
     );
   }
 }

--- a/web/html/src/components/formulas/FormulaComponentGenerator.tsx
+++ b/web/html/src/components/formulas/FormulaComponentGenerator.tsx
@@ -43,6 +43,7 @@ type Context = {
   validate: any | null;
   sectionsExpanded: any | null;
   setSectionsExpanded: any | null;
+  searchCriteria: any | null;
 };
 
 export const FormulaFormContext = React.createContext<Context>({
@@ -55,6 +56,7 @@ export const FormulaFormContext = React.createContext<Context>({
   validate: null,
   sectionsExpanded: null,
   setSectionsExpanded: null,
+  searchCriteria: null,
 });
 
 export function generateFormulaComponent(
@@ -340,6 +342,18 @@ function checkVisibilityCondition(id, condition, formulaForm) {
   return false;
 }
 
+// return the element content visibility conditionally based on the element name by the criteria
+const collapsedByCriteria = (element, criteria) => {
+  return (
+      criteria ||
+      (
+        element.$name &&
+        criteria.length > 0 &&
+        element.$name.toLowerCase().includes(criteria.toLowerCase())
+      )
+  );
+}
+
 function generateChildrenFormItems(element, value, formulaForm, id, disabled = false) {
   var child_items: React.ReactNode[] = [];
   for (var child_name in element) {
@@ -433,6 +447,7 @@ type UnwrappedFormulaFormRendererProps = {
   layout?: any;
   onChange?: (id: string, value: string) => any;
   registerValidationTrigger?: (...args: any[]) => any;
+  searchCriteria: string | null;
 };
 
 // layout
@@ -607,6 +622,7 @@ type FormulaFormContextProviderProps = {
   scope?: any;
   sectionsExpanded?: string | undefined;
   setSectionsExpanded?: (status: string) => void | undefined;
+  searchCriteria?: string;
 };
 
 type FormulaFormContextProviderState = {
@@ -620,6 +636,7 @@ type FormulaFormContextProviderState = {
 // systemData
 // groupData
 // scope
+// searchCriteria
 export class FormulaFormContextProvider extends React.Component<
   FormulaFormContextProviderProps,
   FormulaFormContextProviderState
@@ -651,6 +668,7 @@ export class FormulaFormContextProvider extends React.Component<
       registerValidationTrigger: this.registerValidationTrigger,
       sectionsExpanded: this.props.sectionsExpanded,
       setSectionsExpanded: this.props.setSectionsExpanded,
+      searchCriteria: this.props.searchCriteria,
     };
 
     return <FormulaFormContext.Provider value={contextValue}>{this.props.children}</FormulaFormContext.Provider>;

--- a/web/html/src/components/formulas/FormulaComponentGenerator.tsx
+++ b/web/html/src/components/formulas/FormulaComponentGenerator.tsx
@@ -205,6 +205,7 @@ export function generateFormulaComponentForId(
         help={element.$help}
         sectionsExpanded={formulaForm.props.sectionsExpanded}
         setSectionsExpanded={formulaForm.props.setSectionsExpanded}
+        isVisibleByCriteria={() => isVisibleByCriteria(element, formulaForm.props.searchCriteria)}
       >
         {generateChildrenFormItems(element, value, formulaForm, id, isDisabled)}
       </Group>
@@ -221,6 +222,7 @@ export function generateFormulaComponentForId(
         disabled={isDisabled}
         sectionsExpanded={formulaForm.props.sectionsExpanded}
         setSectionsExpanded={formulaForm.props.setSectionsExpanded}
+        isVisibleByCriteria={() => isVisibleByCriteria(element, formulaForm.props.searchCriteria)}
       />
     );
   } else if (element.$type === "select")
@@ -343,14 +345,21 @@ function checkVisibilityCondition(id, condition, formulaForm) {
 }
 
 // return the element content visibility conditionally based on the element name by the criteria
-const collapsedByCriteria = (element, criteria) => {
+function isVisibleByCriteria(element, criteria) {
+  let visibilityForcedByChildren = false;
+  // check if all children are not visible by criteria so we can hide the parent (this element) as well
+  for (var child_name in element) {
+    if (child_name.startsWith("$")) continue;
+    visibilityForcedByChildren = isVisibleByCriteria(element[child_name], criteria);
+    if (visibilityForcedByChildren) break;
+  }
+
+  // return conditions result whether the element can be hided or not
   return (
-      criteria ||
-      (
-        element.$name &&
-        criteria.length > 0 &&
-        element.$name.toLowerCase().includes(criteria.toLowerCase())
-      )
+      criteria == null ||
+      criteria === "" ||
+      element.$name.toLowerCase().includes(criteria.toLowerCase()) ||
+      visibilityForcedByChildren
   );
 }
 

--- a/web/html/src/components/formulas/FormulaComponentGenerator.tsx
+++ b/web/html/src/components/formulas/FormulaComponentGenerator.tsx
@@ -206,6 +206,7 @@ export function generateFormulaComponentForId(
         sectionsExpanded={formulaForm.props.sectionsExpanded}
         setSectionsExpanded={formulaForm.props.setSectionsExpanded}
         isVisibleByCriteria={() => isVisibleByCriteria(element, formulaForm.props.searchCriteria)}
+        criteria={formulaForm.props.searchCriteria}
       >
         {generateChildrenFormItems(element, value, formulaForm, id, isDisabled)}
       </Group>
@@ -223,6 +224,7 @@ export function generateFormulaComponentForId(
         sectionsExpanded={formulaForm.props.sectionsExpanded}
         setSectionsExpanded={formulaForm.props.setSectionsExpanded}
         isVisibleByCriteria={() => isVisibleByCriteria(element, formulaForm.props.searchCriteria)}
+        criteria={formulaForm.props.searchCriteria}
       />
     );
   } else if (element.$type === "select")
@@ -344,8 +346,12 @@ function checkVisibilityCondition(id, condition, formulaForm) {
   return false;
 }
 
+export function isFiltered(criteria) {
+  return criteria && criteria.length > 0;
+}
+
 // return the element content visibility conditionally based on the element name by the criteria
-function isVisibleByCriteria(element, criteria) {
+function isVisibleByCriteria(element: any, criteria: string) {
   let visibilityForcedByChildren = false;
   // check if all children are not visible by criteria so we can hide the parent (this element) as well
   for (var child_name in element) {

--- a/web/html/src/components/formulas/Group.tsx
+++ b/web/html/src/components/formulas/Group.tsx
@@ -10,6 +10,7 @@ type Props = {
   header?: React.ReactNode;
   help?: React.ReactNode;
   children?: React.ReactNode;
+  isVisibleByCriteria?: any;
 };
 
 const Group = (props: Props) => {
@@ -31,25 +32,28 @@ const Group = (props: Props) => {
   };
 
   return (
-    <div
-      className={
-        visible ? "formula-content-section-open group-heading" : "formula-content-section-closed group-heading"
-      }
-    >
-      <SectionToggle setVisible={setVisibility} isVisible={isVisible}>
-        <h4 id={props.id} key={props.id}>
-          {props.header}
-        </h4>
-      </SectionToggle>
-      <div>
-        {visible ? (
-          <React.Fragment>
-            {props.help ? <p>{props.help}</p> : null}
-            {props.children}
-          </React.Fragment>
-        ) : null}
+    props.isVisibleByCriteria?.() ?
+      <div
+        className={
+          visible ? "formula-content-section-open group-heading" : "formula-content-section-closed group-heading"
+        }
+      >
+        <SectionToggle setVisible={setVisibility} isVisible={isVisible}>
+          <h4 id={props.id} key={props.id}>
+            {props.header}
+          </h4>
+        </SectionToggle>
+        <div>
+          {visible ? (
+            <React.Fragment>
+              {props.help ? <p>{props.help}</p> : null}
+              {props.children}
+            </React.Fragment>
+          ) : null}
+
+        </div>
       </div>
-    </div>
+      : null
   );
 };
 

--- a/web/html/src/components/formulas/Group.tsx
+++ b/web/html/src/components/formulas/Group.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 import { useEffect, useState } from "react";
 
+import { isFiltered } from "./FormulaComponentGenerator";
 import SectionToggle from "./SectionToggle";
+import { Highlight } from "components/table/Highlight";
 
 type Props = {
   id: string;
@@ -11,6 +13,7 @@ type Props = {
   help?: React.ReactNode;
   children?: React.ReactNode;
   isVisibleByCriteria?: any;
+  criteria: string;
 };
 
 const Group = (props: Props) => {
@@ -40,7 +43,11 @@ const Group = (props: Props) => {
       >
         <SectionToggle setVisible={setVisibility} isVisible={isVisible}>
           <h4 id={props.id} key={props.id}>
-            {props.header}
+            {
+              isFiltered(props.criteria) ?
+                <Highlight enabled={isFiltered(props.criteria)} text={props.header ? props.header.toString() : ""} highlight={props.criteria} />
+                : props.header
+            }
           </h4>
         </SectionToggle>
         <div>

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Provide a search box on section name for Formulas content
 - Add expand/collapse all button for formula sections
 - Disable the SPA engine for download links (bsc#1190964)
 - Fix datetime format parsing with moment (bsc#1191348)


### PR DESCRIPTION
## What does this PR change?

Provide a search box in the Formulas context. **Note**: the search box is capable to filter in/out by the section name whether the section is a `group` or an `edit group` type **only**.

## GUI diff

Before:
![before-formulas](https://user-images.githubusercontent.com/7080830/137133219-8f3c285c-3406-4ee9-baba-b2f251dbfea8.png)


After:

![after-formulas1](https://user-images.githubusercontent.com/7080830/137133238-5bf036b9-6c0b-468b-9d4c-271ecf79b0b0.png)
![after-formulas2](https://user-images.githubusercontent.com/7080830/137133250-7b3ba950-161b-4e4f-94c2-895ebfee26ce.png)


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes #2 https://github.com/SUSE/spacewalk/issues/13405
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
